### PR TITLE
Fix map pin size scaling

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -54,7 +54,7 @@ const MapView = forwardRef<MapViewRef, MapViewProps>(({
       if (showOnlyChecked && !checkedIds.has(pt.id)) return;
       if (showOnlyUnchecked && checkedIds.has(pt.id)) return;
 
-      const icon = createMapPinIcon(pt.characterId?? 'default');
+      const icon = createMapPinIcon(pt.characterId ?? 'default', size);
 
       const marker = L.marker([pt.lat, pt.lng], { icon });
 

--- a/src/components/createMapPinIcon.tsx
+++ b/src/components/createMapPinIcon.tsx
@@ -1,12 +1,20 @@
 import L from 'leaflet';
 import characterColorMap from '../config/characterColorMap';
 
-const createMapPinIcon = (characterId: string): L.DivIcon => {
+/**
+ * Create a coloured map pin icon with optional size.
+ *
+ * @param characterId Which character the pin belongs to
+ * @param size        Width of the icon in pixels (default: 40)
+ */
+const createMapPinIcon = (characterId: string, size = 40): L.DivIcon => {
   const color = characterColorMap[characterId] || '#888888';
   const avatarUrl = `/data/avatars/${characterId}.png`;
 
+  const height = Math.round((size / 40) * 52);
+
   const svg = `
-    <svg width="40" height="52" viewBox="0 0 40 52" xmlns="http://www.w3.org/2000/svg">
+    <svg width="${size}" height="${height}" viewBox="0 0 40 52" xmlns="http://www.w3.org/2000/svg">
       <path d="M20 0C31 0 40 9 40 20C40 35 20 52 20 52C20 52 0 35 0 20C0 9 9 0 20 0Z" fill="${color}" />
       <circle cx="20" cy="20" r="12" fill="white" />
       <image href="${avatarUrl}" x="8" y="8" width="24" height="24" onerror="this.remove()" />
@@ -16,9 +24,9 @@ const createMapPinIcon = (characterId: string): L.DivIcon => {
   return L.divIcon({
     className: '',
     html: svg,
-    iconSize: [40, 52],
-    iconAnchor: [20, 52],
-    popupAnchor: [0, -40],
+    iconSize: [size, height],
+    iconAnchor: [size / 2, height],
+    popupAnchor: [0, -size],
   });
 };
 


### PR DESCRIPTION
## Summary
- resize map pin icons based on zoom
- add optional `size` parameter to `createMapPinIcon`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc7295b5083219076bd691403c357