### PR TITLE
Implement offline upload queue for compare images

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,10 +3,14 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/theme.css';
 import 'leaflet/dist/leaflet.css';
+import { processPendingUploads } from './utils/compareImageManager';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(<App />);
+
+processPendingUploads();
+window.addEventListener('online', processPendingUploads);
 
 


### PR DESCRIPTION
## Summary
- create pending upload queue in IndexedDB
- support async upload and retry on network restore
- manage pending uploads when deleting images
- trigger retry logic on app start and when coming online

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871841370088321934377d080b0ac29